### PR TITLE
Allow jumbo-frames (which can be 9000 bytes in size)

### DIFF
--- a/packet_sniffer.py
+++ b/packet_sniffer.py
@@ -34,7 +34,7 @@ class PacketSniffer(object):
             if self.interface is not None:
                 sock.bind((self.interface, 0))
             for self.packet_num in count(1):
-                raw_packet = sock.recv(2048)
+                raw_packet = sock.recv(9000)
                 start: int = 0
                 for proto in self.protocol_queue:
                     proto_class = getattr(protocols, proto)


### PR DESCRIPTION
An mtu of 2048 is not big enough in all Ethernet situations.