### PR TITLE
Resolve netprotocols from PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,16 @@
 name: CI
 
-# Until netprotocols 1.0.0 is published to PyPI, the library is
-# resolved from a sibling checkout of its repository (matching the
-# [tool.uv.sources] path override in pyproject.toml). Once 1.0.0 is on
-# PyPI, the second checkout step can be dropped.
-
 on:
   push:
-    branches: [master, overhaul]
+    branches: [master]
   pull_request:
     branches: [master]
-
-defaults:
-  run:
-    working-directory: Packet-Sniffer
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          path: Packet-Sniffer
-      - uses: actions/checkout@v5
-        with:
-          repository: EONRaider/NETProtocols
-          ref: overhaul
-          path: NETProtocols
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
@@ -37,13 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          path: Packet-Sniffer
-      - uses: actions/checkout@v5
-        with:
-          repository: EONRaider/NETProtocols
-          ref: overhaul
-          path: NETProtocols
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
@@ -56,13 +33,6 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v5
-        with:
-          path: Packet-Sniffer
-      - uses: actions/checkout@v5
-        with:
-          repository: EONRaider/NETProtocols
-          ref: overhaul
-          path: NETProtocols
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,6 @@ dev = [
     "ruff>=0.9",
 ]
 
-[tool.uv.sources]
-# Development resolves the library from the sibling checkout; releases
-# use the published netprotocols from PyPI (>=1.0). Remove this table
-# once 1.0.0 is on PyPI if a pure-registry resolution is preferred.
-netprotocols = { path = "../NETProtocols", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -354,16 +354,10 @@ wheels = [
 [[package]]
 name = "netprotocols"
 version = "1.0.0"
-source = { editable = "../NETProtocols" }
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy", specifier = ">=1.14" },
-    { name = "pytest", specifier = ">=8.3" },
-    { name = "pytest-cov", specifier = ">=6.0" },
-    { name = "ruff", specifier = ">=0.9" },
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/8f/f96154ba289fd84cb8bb3082cf16363f1b30bec9e090ded7fdb9cfcd9d99/netprotocols-1.0.0.tar.gz", hash = "sha256:71448d1c15b53d4b48a37fce1e00773362d272f748b43e749304ca303527d932", size = 59325, upload-time = "2026-08-21T22:02:16.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/ea/8962b2d99dc62dfa12293f29440729e2f46cddf56475aad9e10d71115a70/netprotocols-1.0.0-py3-none-any.whl", hash = "sha256:5d7509340a2c2701371cdcf71a34a945e7d5fe1f8a53d6a8542b31187e9fcde8", size = 21109, upload-time = "2026-08-21T22:02:14.964Z" },
 ]
 
 [[package]]
@@ -392,7 +386,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "netprotocols", editable = "../NETProtocols" }]
+requires-dist = [{ name = "netprotocols", specifier = ">=1.0,<2" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
netprotocols 1.0.0 is on PyPI: drops the [tool.uv.sources] path override, relocks, and simplifies CI (no second checkout, no overhaul trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)