### PR TITLE
pcap output and file replay

### DIFF
--- a/src/packet_sniffer/cli.py
+++ b/src/packet_sniffer/cli.py
@@ -1,15 +1,21 @@
 """Command-line interface: argument parsing, privilege guidance, and
-the capture loop wiring frames through the decoder to the renderers."""
+the loop wiring frames from a source (live capture or pcap replay)
+through the decoder to the outputs.
+
+Everything informational — banner, abort notice, statistics — goes to
+stderr, so stdout stays clean for machine-readable output
+(``--json`` NDJSON pipes straight into ``jq``).
+"""
 
 from __future__ import annotations
 
 import argparse
 import sys
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 
 from packet_sniffer import __version__
 from packet_sniffer.decoder import decode_frame
-from packet_sniffer.output import Output, OutputToScreen
+from packet_sniffer.output import Output, OutputToPcap, OutputToScreen
 
 __all__ = ["build_parser", "main"]
 
@@ -19,8 +25,8 @@ def build_parser() -> argparse.ArgumentParser:
         prog="packet-sniffer",
         description=(
             "Monitor network traffic: capture Ethernet frames from an "
-            "interface, decode their protocol stack and render each frame "
-            "on screen."
+            "interface (or replay them from a pcap file), decode their "
+            "protocol stack and render each frame."
         ),
     )
     parser.add_argument(
@@ -28,6 +34,23 @@ def build_parser() -> argparse.ArgumentParser:
         "--interface",
         default=None,
         help="interface to capture frames from (default: all interfaces)",
+    )
+    parser.add_argument(
+        "-r",
+        "--read",
+        metavar="FILE",
+        default=None,
+        help=(
+            "replay frames from a classic pcap file instead of live "
+            "capture (no privileges required); mutually exclusive with -i"
+        ),
+    )
+    parser.add_argument(
+        "-w",
+        "--write",
+        metavar="FILE",
+        default=None,
+        help="also write every captured frame to a classic pcap file",
     )
     parser.add_argument(
         "-d",
@@ -41,15 +64,17 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def run(interface: str | None, outputs: Sequence[Output]) -> int:
-    """Capture, decode, and dispatch frames until interrupted.
+def run(
+    source: Iterator[tuple[bytes, float]],
+    interface: str | None,
+    outputs: Sequence[Output],
+) -> int:
+    """Decode and dispatch every frame the source yields.
 
     :returns: The number of frames processed.
     """
-    from packet_sniffer.capture import capture  # Linux-only import
-
     number = 0
-    for number, (data, timestamp) in enumerate(capture(interface), start=1):
+    for number, (data, timestamp) in enumerate(source, start=1):
         frame = decode_frame(
             data, number=number, timestamp=timestamp, interface=interface
         )
@@ -60,13 +85,36 @@ def run(interface: str | None, outputs: Sequence[Output]) -> int:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    outputs = [OutputToScreen(display_payload=args.data)]
+    if args.read is not None and args.interface is not None:
+        build_parser().error("-r/--read and -i/--interface are exclusive")
+
+    outputs: list[Output] = [OutputToScreen(display_payload=args.data)]
+    if args.write is not None:
+        outputs.append(OutputToPcap(args.write))
+
+    if args.read is not None:
+        from packet_sniffer.pcap import read_pcap
+
+        source = read_pcap(args.read)
+        interface = args.read
+    else:
+        from packet_sniffer.capture import capture  # Linux-only import
+
+        source = capture(args.interface)
+        interface = args.interface
+
     print(
-        "[>>>] Packet Sniffer initialized. Waiting for incoming data. "
-        "Press Ctrl-C to abort...\n"
+        "[>>>] Packet Sniffer initialized. "
+        + (
+            f"Replaying {args.read}..."
+            if args.read
+            else "Waiting for incoming data. Press Ctrl-C to abort..."
+        ),
+        file=sys.stderr,
     )
+    exit_code = 0
     try:
-        run(args.interface, outputs)
+        run(source, interface, outputs)
     except PermissionError:
         print(
             "Error: opening a raw socket requires elevated privileges. "
@@ -74,10 +122,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             "capability.",
             file=sys.stderr,
         )
-        return 1
+        exit_code = 1
+    except ValueError as e:  # unreadable/foreign pcap on -r
+        print(f"Error: {e}", file=sys.stderr)
+        exit_code = 1
     except KeyboardInterrupt:
-        print("[!] Capture aborted.")
-    return 0
+        print("[!] Capture aborted.", file=sys.stderr)
+    finally:
+        for output in outputs:
+            output.close()
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/src/packet_sniffer/decoder.py
+++ b/src/packet_sniffer/decoder.py
@@ -81,4 +81,5 @@ def decode_frame(
         payload=bytes(view[cursor:]),
         truncated=declared is not None and declared > len(data),
         error=error,
+        raw=data,
     )

--- a/src/packet_sniffer/frame.py
+++ b/src/packet_sniffer/frame.py
@@ -34,6 +34,9 @@ class DecodedFrame:
     :param error: Diagnostic message when the decode chain aborted on a
         malformed header, else ``None``. The layers decoded before the
         failure are preserved.
+    :param raw: The exact captured bytes of the whole frame — the same
+        object the decoder received, so keeping it costs no copy. This
+        is what pcap output writes.
     """
 
     number: int
@@ -44,6 +47,7 @@ class DecodedFrame:
     payload: bytes
     truncated: bool = False
     error: str | None = None
+    raw: bytes = b""
 
     def layer(self, protocol: type[_P]) -> _P | None:
         """The first decoded layer of the given class, or ``None``.

--- a/src/packet_sniffer/output.py
+++ b/src/packet_sniffer/output.py
@@ -48,8 +48,12 @@ class Output(ABC):
     def update(self, frame: DecodedFrame) -> None:
         """Process one decoded frame."""
 
-    def close(self) -> None:
-        """Release resources at end of capture; default: nothing."""
+    def close(self) -> None:  # noqa: B027 -- optional hook, not abstract
+        """Release resources at end of capture; default: nothing.
+
+        Deliberately not abstract: most outputs hold no resources, and
+        forcing every renderer to write a no-op close would be noise.
+        """
 
 
 class OutputToScreen(Output):

--- a/src/packet_sniffer/output.py
+++ b/src/packet_sniffer/output.py
@@ -33,8 +33,9 @@ from netprotocols import (
 )
 
 from packet_sniffer.frame import DecodedFrame
+from packet_sniffer.pcap import PcapWriter
 
-__all__ = ["Output", "OutputToScreen"]
+__all__ = ["Output", "OutputToPcap", "OutputToScreen"]
 
 _I = " " * 4  # base indentation for layer sections
 _II = " " * 8  # indentation for field detail lines
@@ -46,6 +47,9 @@ class Output(ABC):
     @abstractmethod
     def update(self, frame: DecodedFrame) -> None:
         """Process one decoded frame."""
+
+    def close(self) -> None:
+        """Release resources at end of capture; default: nothing."""
 
 
 class OutputToScreen(Output):
@@ -225,3 +229,20 @@ class OutputToScreen(Output):
         self._print(
             f"{_II}Length: {layer.length} | Checksum: {layer.checksum_hex_str}"
         )
+
+
+class OutputToPcap(Output):
+    """Write every frame's exact captured bytes to a classic pcap file.
+
+    :param path: Destination file, created (or overwritten) on
+        construction.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._writer = PcapWriter(path)
+
+    def update(self, frame: DecodedFrame) -> None:
+        self._writer.write(frame.raw, frame.timestamp)
+
+    def close(self) -> None:
+        self._writer.close()

--- a/src/packet_sniffer/pcap.py
+++ b/src/packet_sniffer/pcap.py
@@ -1,0 +1,137 @@
+"""Classic pcap file writing and replay, dependency-free.
+
+The writer emits the classic (not pcapng) format: a 24-byte global
+header — magic ``0xA1B2C3D4``, version 2.4, thiszone 0, sigfigs 0,
+snaplen matching the capture buffer, linktype 1 (Ethernet) — followed
+by 16-byte per-record headers. Timestamps are written with microsecond
+precision, little-endian, which every tool (Wireshark, tcpdump, tshark)
+reads.
+
+The reader accepts both byte orders and the nanosecond-precision magic
+(``0xA1B23C4D``), validates that the file carries Ethernet frames
+before handing them to an Ethernet decoder, and deliberately has the
+same shape as :func:`packet_sniffer.capture.capture` — so replaying a
+file is a drop-in frame source for the whole pipeline, no root
+required.
+
+``orig_len`` is written equal to ``incl_len``: a frame delivered by
+``recv()`` carries no record of a kernel-side truncation, so the
+captured length is the only honest value.
+"""
+
+from __future__ import annotations
+
+import struct
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from types import TracebackType
+from typing import BinaryIO, Self
+
+__all__ = ["PcapWriter", "read_pcap"]
+
+#: Matches capture.BUFFER_SIZE without importing that module — capture
+#: is the one Linux-only module (PF_PACKET), and replaying a file must
+#: work anywhere.
+_SNAPLEN = 65_550
+
+_MAGIC_MICROSECONDS = 0xA1B2C3D4
+_MAGIC_NANOSECONDS = 0xA1B23C4D
+_LINKTYPE_ETHERNET = 1
+_GLOBAL_HEADER = struct.Struct("<IHHiIII")
+_RECORD_HEADER = struct.Struct("<IIII")
+
+
+class PcapWriter:
+    """Write frames to a classic pcap file; usable as a context manager.
+
+    >>> with PcapWriter("capture.pcap") as writer:
+    ...     writer.write(frame_bytes, timestamp)
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._file: BinaryIO = open(path, "wb")  # noqa: SIM115
+        self._file.write(
+            _GLOBAL_HEADER.pack(
+                _MAGIC_MICROSECONDS,
+                2,  # version major
+                4,  # version minor
+                0,  # thiszone
+                0,  # sigfigs
+                _SNAPLEN,
+                _LINKTYPE_ETHERNET,
+            )
+        )
+
+    def write(self, data: bytes, timestamp: float | None = None) -> None:
+        """Append one frame with the given capture timestamp (now, if
+        omitted)."""
+        if timestamp is None:
+            timestamp = time.time()
+        ts_sec = int(timestamp)
+        ts_usec = round((timestamp - ts_sec) * 1_000_000)
+        if ts_usec == 1_000_000:  # rounding carried into the next second
+            ts_sec += 1
+            ts_usec = 0
+        self._file.write(
+            _RECORD_HEADER.pack(ts_sec, ts_usec, len(data), len(data))
+        )
+        self._file.write(data)
+
+    def close(self) -> None:
+        self._file.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+def read_pcap(path: str | Path) -> Iterator[tuple[bytes, float]]:
+    """Yield ``(frame, timestamp)`` pairs from a classic pcap file.
+
+    Accepts both byte orders and both timestamp precisions; rejects
+    files whose linktype is not Ethernet (nothing else can be fed to
+    an Ethernet decoder) and files that end mid-record.
+
+    :raises ValueError: If the file is not classic pcap, carries a
+        non-Ethernet linktype, or is truncated.
+    """
+    data = Path(path).read_bytes()
+    if len(data) < _GLOBAL_HEADER.size:
+        raise ValueError(f"{path}: too short to be a pcap file")
+    magic_le = struct.unpack_from("<I", data)[0]
+    magic_be = struct.unpack_from(">I", data)[0]
+    if magic_le in (_MAGIC_MICROSECONDS, _MAGIC_NANOSECONDS):
+        endian, magic = "<", magic_le
+    elif magic_be in (_MAGIC_MICROSECONDS, _MAGIC_NANOSECONDS):
+        endian, magic = ">", magic_be
+    else:
+        raise ValueError(f"{path}: not a classic pcap file")
+    divisor = 1e6 if magic == _MAGIC_MICROSECONDS else 1e9
+    (network,) = struct.unpack_from(f"{endian}I", data, 20)
+    if network != _LINKTYPE_ETHERNET:
+        raise ValueError(
+            f"{path}: linktype {network} is not Ethernet (1); this file "
+            f"cannot be replayed through an Ethernet decoder"
+        )
+    record = struct.Struct(f"{endian}IIII")
+    cursor = _GLOBAL_HEADER.size
+    while cursor < len(data):
+        if cursor + record.size > len(data):
+            raise ValueError(f"{path}: truncated record header")
+        ts_sec, ts_frac, incl_len, _ = record.unpack_from(data, cursor)
+        cursor += record.size
+        if cursor + incl_len > len(data):
+            raise ValueError(f"{path}: truncated frame data")
+        yield (
+            bytes(data[cursor : cursor + incl_len]),
+            ts_sec + ts_frac / divisor,
+        )
+        cursor += incl_len

--- a/tests/test_pcap.py
+++ b/tests/test_pcap.py
@@ -1,0 +1,170 @@
+"""pcap writing and replay: format goldens, round trips, and the whole
+corpus through the file-replay pipeline."""
+
+import struct
+
+import pytest
+
+from conftest import FIXTURES, corpus_frames
+from packet_sniffer import cli
+from packet_sniffer.decoder import decode_frame
+from packet_sniffer.output import Output, OutputToPcap
+from packet_sniffer.pcap import PcapWriter, read_pcap
+
+FRAMES = [
+    b"\xff" * 6 + b"\x00" * 6 + b"\x08\x06" + b"arp-ish",
+    b"\x00" * 14,
+]
+TIMESTAMPS = [1_787_000_000.123456, 1_787_000_000.999999]
+
+
+class TestWriterFormat:
+    def test_global_header_golden_bytes(self, tmp_path):
+        path = tmp_path / "empty.pcap"
+        PcapWriter(path).close()
+        assert path.read_bytes() == struct.pack(
+            "<IHHiIII", 0xA1B2C3D4, 2, 4, 0, 0, 65_550, 1
+        )
+
+    def test_record_headers_carry_exact_microseconds(self, tmp_path):
+        path = tmp_path / "two.pcap"
+        with PcapWriter(path) as writer:
+            for frame, timestamp in zip(FRAMES, TIMESTAMPS, strict=True):
+                writer.write(frame, timestamp)
+        data = path.read_bytes()
+        cursor = 24
+        seen = []
+        for frame in FRAMES:
+            ts_sec, ts_usec, incl_len, orig_len = struct.unpack_from(
+                "<IIII", data, cursor
+            )
+            assert incl_len == orig_len == len(frame)
+            seen.append((ts_sec, ts_usec))
+            cursor += 16 + incl_len
+        # Integer comparison: float µs at 2026 epoch values is lossy.
+        assert seen[0] == (1_787_000_000, 123456)
+        assert seen[1] == (1_787_000_000, 999999)
+
+    def test_microsecond_rounding_carries_into_the_next_second(self, tmp_path):
+        path = tmp_path / "carry.pcap"
+        with PcapWriter(path) as writer:
+            writer.write(b"x" * 14, 1_787_000_000.9999999)
+        ts_sec, ts_usec = struct.unpack_from("<II", path.read_bytes(), 24)
+        assert (ts_sec, ts_usec) == (1_787_000_001, 0)
+
+
+class TestReader:
+    def test_write_read_round_trip(self, tmp_path):
+        path = tmp_path / "roundtrip.pcap"
+        with PcapWriter(path) as writer:
+            for frame, timestamp in zip(FRAMES, TIMESTAMPS, strict=True):
+                writer.write(frame, timestamp)
+        replayed = list(read_pcap(path))
+        assert [frame for frame, _ in replayed] == FRAMES
+
+    def test_big_endian_and_nanosecond_magic(self, tmp_path):
+        for magic, divisor, name in (
+            (0xA1B2C3D4, 1_000_000, "be-us"),
+            (0xA1B23C4D, 1_000_000_000, "be-ns"),
+        ):
+            path = tmp_path / f"{name}.pcap"
+            frame = FRAMES[0]
+            path.write_bytes(
+                struct.pack(">IHHiIII", magic, 2, 4, 0, 0, 65_550, 1)
+                + struct.pack(
+                    ">IIII",
+                    1_787_000_000,
+                    divisor // 2,
+                    len(frame),
+                    len(frame),
+                )
+                + frame
+            )
+            ((replayed, timestamp),) = list(read_pcap(path))
+            assert replayed == frame
+            assert timestamp == pytest.approx(1_787_000_000.5)
+
+    def test_non_ethernet_linktype_rejected(self, tmp_path):
+        path = tmp_path / "raw-ip.pcap"
+        path.write_bytes(
+            struct.pack("<IHHiIII", 0xA1B2C3D4, 2, 4, 0, 0, 65_550, 101)
+        )
+        with pytest.raises(ValueError, match="linktype 101"):
+            list(read_pcap(path))
+
+    def test_not_a_pcap_rejected(self, tmp_path):
+        path = tmp_path / "not.pcap"
+        path.write_bytes(b"PK\x03\x04 definitely a zip" + b"\x00" * 16)
+        with pytest.raises(ValueError, match="not a classic pcap"):
+            list(read_pcap(path))
+
+    def test_truncated_record_diagnosed(self, tmp_path):
+        path = tmp_path / "cut.pcap"
+        with PcapWriter(path) as writer:
+            writer.write(FRAMES[0], TIMESTAMPS[0])
+        path.write_bytes(path.read_bytes()[:-4])
+        with pytest.raises(ValueError, match="truncated"):
+            list(read_pcap(path))
+
+
+class TestCorpusReplay:
+    def test_every_corpus_pcap_replays_through_the_pipeline(self):
+        """read_pcap must agree with the independent test reader and
+        feed the decoder cleanly — the corpus doubles as the replay
+        golden set."""
+        expected = {}
+        for name, _, frame in corpus_frames():
+            expected.setdefault(name, []).append(frame)
+        for pcap in sorted(FIXTURES.glob("*.pcap")):
+            replayed = list(read_pcap(pcap))
+            assert [f for f, _ in replayed] == expected[pcap.name]
+            for number, (data, timestamp) in enumerate(replayed, start=1):
+                frame = decode_frame(
+                    data,
+                    number=number,
+                    timestamp=timestamp,
+                    interface=str(pcap),
+                )
+                assert frame.layers
+                assert frame.raw == data
+
+
+class TestCaptureToPcapOutput:
+    def test_output_writes_frames_byte_exactly(self, tmp_path, arp_frame):
+        path = tmp_path / "out.pcap"
+        output: Output = OutputToPcap(str(path))
+        frame = decode_frame(
+            arp_frame, number=1, timestamp=TIMESTAMPS[0], interface=None
+        )
+        output.update(frame)
+        output.close()
+        ((replayed, _),) = list(read_pcap(path))
+        assert replayed == arp_frame
+
+
+class TestCLIReplay:
+    def test_replay_needs_no_root_and_reports_frames(self, tmp_path, capsys):
+        source = FIXTURES / "arp_exchange.pcap"
+        assert cli.main(["-r", str(source)]) == 0
+        captured = capsys.readouterr()
+        assert "Replaying" in captured.err
+        assert "Frame #" in captured.out
+
+    def test_replay_transform_copy(self, tmp_path, capsys):
+        source = FIXTURES / "udp_dns.pcap"
+        copy = tmp_path / "copy.pcap"
+        assert cli.main(["-r", str(source), "-w", str(copy)]) == 0
+        assert [f for f, _ in read_pcap(copy)] == [
+            f for f, _ in read_pcap(source)
+        ]
+
+    def test_read_and_interface_are_exclusive(self):
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main(["-r", "x.pcap", "-i", "eth0"])
+        assert excinfo.value.code == 2
+
+    def test_unreadable_pcap_is_a_clean_error(self, tmp_path, capsys):
+        bad = tmp_path / "bad.pcap"
+        bad.write_bytes(b"nonsense" * 4)
+        assert cli.main(["-r", str(bad)]) == 1
+        assert "Error:" in capsys.readouterr().err


### PR DESCRIPTION
Milestone v4.1, item A-1. Classic pcap writer/reader (dependency-free), -w/-r CLI flags, DecodedFrame.raw, output close() lifecycle, stderr hygiene; corpus pcaps double as replay goldens.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)