### PR TITLE
NDJSON output and capture statistics

### DIFF
--- a/src/packet_sniffer/cli.py
+++ b/src/packet_sniffer/cli.py
@@ -15,7 +15,13 @@ from collections.abc import Iterator, Sequence
 
 from packet_sniffer import __version__
 from packet_sniffer.decoder import decode_frame
-from packet_sniffer.output import Output, OutputToPcap, OutputToScreen
+from packet_sniffer.output import (
+    Output,
+    OutputToNDJSON,
+    OutputToPcap,
+    OutputToScreen,
+    StatsCollector,
+)
 
 __all__ = ["build_parser", "main"]
 
@@ -53,10 +59,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="also write every captured frame to a classic pcap file",
     )
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "emit one NDJSON object per frame on stdout instead of the "
+            "human-readable rendering"
+        ),
+    )
+    parser.add_argument(
         "-d",
         "--data",
         action="store_true",
-        help="also display each frame's raw payload",
+        help="also display each frame's raw payload (ignored with --json)",
     )
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
@@ -88,9 +102,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.read is not None and args.interface is not None:
         build_parser().error("-r/--read and -i/--interface are exclusive")
 
-    outputs: list[Output] = [OutputToScreen(display_payload=args.data)]
+    stats = StatsCollector()
+    outputs: list[Output] = [
+        OutputToNDJSON()
+        if args.json
+        else OutputToScreen(display_payload=args.data)
+    ]
     if args.write is not None:
         outputs.append(OutputToPcap(args.write))
+    outputs.append(stats)
 
     if args.read is not None:
         from packet_sniffer.pcap import read_pcap
@@ -131,6 +151,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     finally:
         for output in outputs:
             output.close()
+        if exit_code == 0:
+            stats.report()
     return exit_code
 
 

--- a/src/packet_sniffer/output.py
+++ b/src/packet_sniffer/output.py
@@ -1,4 +1,4 @@
-"""Renderers for decoded frames.
+"""Renderers and other consumers of decoded frames.
 
 ``OutputToScreen`` dispatches on the *type* of each decoded layer via
 ``singledispatchmethod`` and always receives the whole
@@ -10,11 +10,14 @@ instead of raising: display helpers must never kill a capture.
 
 from __future__ import annotations
 
+import dataclasses
+import json
 import sys
 import time
 from abc import ABC, abstractmethod
+from collections import Counter
 from functools import singledispatchmethod
-from typing import IO
+from typing import IO, Any, cast
 
 from netprotocols import (
     ARP,
@@ -35,7 +38,13 @@ from netprotocols import (
 from packet_sniffer.frame import DecodedFrame
 from packet_sniffer.pcap import PcapWriter
 
-__all__ = ["Output", "OutputToPcap", "OutputToScreen"]
+__all__ = [
+    "Output",
+    "OutputToNDJSON",
+    "OutputToPcap",
+    "OutputToScreen",
+    "StatsCollector",
+]
 
 _I = " " * 4  # base indentation for layer sections
 _II = " " * 8  # indentation for field detail lines
@@ -250,3 +259,113 @@ class OutputToPcap(Output):
 
     def close(self) -> None:
         self._writer.close()
+
+
+def _json_safe(value: Any) -> Any:
+    return value.hex() if isinstance(value, bytes) else value
+
+
+class OutputToNDJSON(Output):
+    """Emit one JSON object per frame, newline-delimited.
+
+    Layer fields come straight from the dataclasses (bytes values
+    hex-encoded); the raw payload is deliberately omitted — its length
+    is reported as ``payload_len``. Lines are flushed as they are
+    written so the output pipes cleanly into consumers like ``jq``.
+
+    :param stream: Destination stream; defaults to stdout.
+    """
+
+    def __init__(self, stream: IO[str] | None = None) -> None:
+        self._stream = stream if stream is not None else sys.stdout
+
+    def update(self, frame: DecodedFrame) -> None:
+        record = {
+            "number": frame.number,
+            "timestamp": frame.timestamp,
+            "interface": frame.interface,
+            "length": frame.length,
+            "truncated": frame.truncated,
+            "error": frame.error,
+            "payload_len": len(frame.payload),
+            "layers": [
+                {
+                    "type": type(layer).__name__,
+                    **{
+                        key: _json_safe(value)
+                        # Every concrete Protocol is a dataclass; the
+                        # ABC itself is not, hence the cast.
+                        for key, value in dataclasses.asdict(
+                            cast(Any, layer)
+                        ).items()
+                    },
+                }
+                for layer in frame.layers
+            ],
+        }
+        print(
+            json.dumps(record, separators=(",", ":")),
+            file=self._stream,
+            flush=True,
+        )
+
+
+#: Innermost-layer classes counted by name in the statistics report.
+_STATS_BUCKETS = (TCP, UDP, ICMPv4, ICMPv6, ARP)
+
+
+class StatsCollector(Output):
+    """Accumulate capture statistics; render them with :meth:`report`.
+
+    The per-protocol tally buckets each frame by its innermost decoded
+    layer among TCP/UDP/ICMPv4/ICMPv6/ARP — unambiguous even when a
+    chain ends at an extension header or a non-first fragment, which
+    count as ``other``.
+    """
+
+    def __init__(self) -> None:
+        self._started = time.monotonic()
+        self._frames = 0
+        self._bytes = 0
+        self._malformed = 0
+        self._truncated = 0
+        self._buckets: Counter[str] = Counter()
+
+    def update(self, frame: DecodedFrame) -> None:
+        self._frames += 1
+        self._bytes += frame.length
+        if frame.error is not None:
+            self._malformed += 1
+        if frame.truncated:
+            self._truncated += 1
+        for layer in reversed(frame.layers):
+            if isinstance(layer, _STATS_BUCKETS):
+                self._buckets[type(layer).__name__] += 1
+                break
+        else:
+            self._buckets["other"] += 1
+
+    def report(self, stream: IO[str] | None = None) -> None:
+        """Write the capture summary (to stderr by default)."""
+        stream = stream if stream is not None else sys.stderr
+        duration = time.monotonic() - self._started
+        rate = self._frames / duration if duration > 0 else 0.0
+        tallies = ", ".join(
+            f"{name}: {count}"
+            for name, count in sorted(
+                self._buckets.items(), key=lambda item: -item[1]
+            )
+        )
+        print(
+            f"[=] {self._frames} frames, {self._bytes:,} bytes in "
+            f"{duration:.1f}s ({rate:,.0f} frames/s)",
+            file=stream,
+        )
+        if tallies:
+            print(f"[=] {tallies}", file=stream)
+        if self._malformed or self._truncated:
+            print(
+                f"[=] malformed: {self._malformed}, "
+                f"truncated: {self._truncated}",
+                file=stream,
+            )

--- a/tests/test_ndjson_stats.py
+++ b/tests/test_ndjson_stats.py
@@ -1,0 +1,128 @@
+"""NDJSON output and capture statistics."""
+
+import io
+import json
+
+from conftest import FIXTURES
+from packet_sniffer import cli
+from packet_sniffer.decoder import decode_frame
+from packet_sniffer.output import OutputToNDJSON, StatsCollector
+
+SCHEMA_KEYS = {
+    "number",
+    "timestamp",
+    "interface",
+    "length",
+    "truncated",
+    "error",
+    "payload_len",
+    "layers",
+}
+
+
+def emit(data: bytes) -> dict:
+    stream = io.StringIO()
+    OutputToNDJSON(stream).update(
+        decode_frame(data, number=7, timestamp=1_787_000_000.5, interface="x")
+    )
+    lines = stream.getvalue().splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+class TestOutputToNDJSON:
+    def test_schema_keys_and_metadata(self, arp_frame):
+        record = emit(arp_frame)
+        assert set(record) == SCHEMA_KEYS
+        assert record["number"] == 7
+        assert record["interface"] == "x"
+        assert record["length"] == len(arp_frame)
+        assert record["error"] is None
+
+    def test_layer_fields_with_hex_encoded_bytes(self, tcp_frame_with_options):
+        record = emit(tcp_frame_with_options)
+        types = [layer["type"] for layer in record["layers"]]
+        assert types == ["Ethernet", "IPv4", "TCP"]
+        tcp = record["layers"][2]
+        assert tcp["src_port"] == 51888
+        assert tcp["options"] == "0101080a0008ca610001692e"
+        assert record["payload_len"] == 16  # "GET / HTTP/1.1\r\n"
+
+    def test_every_corpus_frame_serializes(self):
+        from conftest import corpus_frames
+
+        for _, _, frame in corpus_frames():
+            emit(frame)
+
+
+class TestStatsCollector:
+    def collect(self, frames: list[bytes]) -> StatsCollector:
+        stats = StatsCollector()
+        for number, data in enumerate(frames, start=1):
+            stats.update(
+                decode_frame(data, number=number, timestamp=0.0, interface=None)
+            )
+        return stats
+
+    def test_buckets_by_innermost_known_layer(self, arp_frame, udp_frame):
+        from netprotocols import IPv6Fragment
+
+        from conftest import read_pcap
+
+        mld = read_pcap(FIXTURES / "ipv6_mld.pcap")[0]
+        fragment_non_first = next(
+            data
+            for data in read_pcap(FIXTURES / "ipv6_fragments.pcap")
+            if (
+                lambda frame: (
+                    isinstance(frame.layers[-1], IPv6Fragment)
+                    and frame.layers[-1].fragment_offset > 0
+                )
+            )(decode_frame(data, number=1, timestamp=0.0, interface=None))
+        )
+        stats = self.collect([arp_frame, udp_frame, mld, fragment_non_first])
+        stream = io.StringIO()
+        stats.report(stream)
+        text = stream.getvalue()
+        assert "4 frames" in text
+        assert "ARP: 1" in text
+        assert "UDP: 1" in text
+        assert "ICMPv6: 1" in text  # MLD's innermost layer is ICMPv6
+        assert "other: 1" in text  # non-first fragment ends at the header
+
+    def test_malformed_and_truncated_counters(self, truncated_frame):
+        stats = self.collect([truncated_frame])
+        stream = io.StringIO()
+        stats.report(stream)
+        assert "malformed: 1, truncated: 1" in stream.getvalue()
+
+
+class TestJSONModePurity:
+    def test_stdout_carries_nothing_but_ndjson(self, capsys):
+        source = FIXTURES / "udp_dns.pcap"
+        assert cli.main(["-r", str(source), "--json"]) == 0
+        captured = capsys.readouterr()
+        lines = captured.out.splitlines()
+        assert lines
+        for line in lines:
+            json.loads(line)  # every stdout line must be JSON
+        assert "[>>>]" in captured.err  # banner on stderr
+        assert "frames/s" in captured.err  # stats on stderr
+
+    def test_json_composes_with_write(self, tmp_path, capsys):
+        from packet_sniffer.pcap import read_pcap as replay
+
+        source = FIXTURES / "arp_exchange.pcap"
+        copy = tmp_path / "copy.pcap"
+        assert cli.main(["-r", str(source), "--json", "-w", str(copy)]) == 0
+        for line in capsys.readouterr().out.splitlines():
+            json.loads(line)
+        assert len(list(replay(copy))) == 4
+
+    def test_screen_mode_reports_stats_on_stderr_too(self, capsys):
+        assert cli.main(["-r", str(FIXTURES / "arp_exchange.pcap")]) == 0
+        captured = capsys.readouterr()
+        assert "Frame #" in captured.out
+        assert "frames/s" in captured.err


### PR DESCRIPTION
Milestone v4.1, item A-2. --json NDJSON with strict stdout purity (banner/stats/abort on stderr), hex-safe layer serialization tested across the whole corpus; StatsCollector with innermost-known-layer buckets, reported on Ctrl-C and replay EOF.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)