### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-08-29
+
+### Added
+- **pcap output and replay**: `-w FILE` writes every captured frame
+  byte-exactly to a classic pcap file (opens in Wireshark/tcpdump);
+  `-r FILE` replays a pcap through the whole decode/render pipeline —
+  no privileges required. The reader handles both byte orders and
+  nanosecond-precision files, and rejects non-Ethernet linktypes.
+- **NDJSON output**: `--json` emits one JSON object per frame on
+  stdout with nothing else mixed in (banner, statistics, and the abort
+  notice live on stderr), so output pipes cleanly into `jq` and
+  friends. `-d` is ignored in JSON mode.
+- **Capture statistics** on exit and at replay end-of-file: frames,
+  bytes, duration, frames/s, malformed and truncated counts, and
+  per-protocol tallies bucketed by innermost decoded layer.
+- **IPv6 extension-header rendering** (netprotocols 1.1): MLD traffic
+  now renders as Ethernet / IPv6 / Hop-by-Hop Options / ICMPv6, and
+  fragments are labeled first/at-offset.
+
+### Changed
+- The decode chain is capped at 16 layers per frame (diagnosed on the
+  frame, capture continues): a crafted frame of back-to-back 8-byte
+  extension headers could otherwise decode thousands of layer objects.
+- Dependency floor raised to `netprotocols>=1.1,<2`.
+
 ## [4.0.0] - 2026-08-21
 
 Complete rebuild on netprotocols 1.0. The CLI gains proper entry

--- a/README.md
+++ b/README.md
@@ -48,11 +48,25 @@ uv sync
 ## Usage
 
 ```
-packet-sniffer [-h] [-i INTERFACE] [-d] [--version]
+packet-sniffer [-h] [-i INTERFACE] [-r FILE] [-w FILE] [--json] [-d] [--version]
 
 options:
   -i, --interface   interface to capture frames from (default: all interfaces)
-  -d, --data        also display each frame's raw payload
+  -r, --read FILE   replay frames from a classic pcap file instead of live
+                    capture (no privileges required)
+  -w, --write FILE  also write every captured frame to a classic pcap file
+  --json            one NDJSON object per frame on stdout (banner and
+                    statistics stay on stderr): pipe straight into jq
+  -d, --data        also display each frame's raw payload (ignored with --json)
+```
+
+Capture statistics (frames, bytes, frames/s, per-protocol tallies) are
+reported on stderr when the capture ends. Some favorite combinations:
+
+```
+sudo packet-sniffer -i eth0 -w session.pcap   # capture and keep the evidence
+packet-sniffer -r session.pcap                # inspect it later, no root
+packet-sniffer -r session.pcap --json | jq .  # machine-readable analysis
 ```
 
 Capturing requires a raw socket, which on Linux means either root:
@@ -84,9 +98,8 @@ uv run pytest
 ## Roadmap
 
 - BPF filtering (kernel-side capture filters)
-- pcap/pcapng file output and replay-from-pcap input
-- JSON/NDJSON output for piping into other tools
-- Kernel timestamps (`SO_TIMESTAMPNS`)
+- Kernel timestamps (`SO_TIMESTAMPNS`) and SIGTERM-clean service use
+- Checksum verification rendering
 - A new name — watch this space
 
 ## Legal Disclaimer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "packet-sniffer"
-version = "4.0.0"
+version = "4.1.0"
 description = "A network traffic monitor that decodes raw Ethernet frames"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/packet_sniffer/__init__.py
+++ b/src/packet_sniffer/__init__.py
@@ -3,6 +3,6 @@ frames with the netprotocols library."""
 
 from packet_sniffer.frame import DecodedFrame
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"
 
 __all__ = ["DecodedFrame", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "packet-sniffer"
-version = "4.0.0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "netprotocols" },


### PR DESCRIPTION
Milestone v4.1: pcap write/replay, NDJSON output, capture statistics, extension-header rendering, decode-chain hardening. 173 tests, mypy strict, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)