### PR TITLE
Render 802.1Q VLAN tags; end-to-end tagged-frame decode tests

### DIFF
--- a/src/rootwire/output.py
+++ b/src/rootwire/output.py
@@ -23,6 +23,7 @@ from netprotocols import (
     ARP,
     TCP,
     UDP,
+    VLAN,
     Ethernet,
     ICMPv4,
     ICMPv6,
@@ -242,6 +243,14 @@ class OutputToScreen(Output):
         self._print(
             f"{_II}Length: {layer.length} | Checksum: {layer.checksum_hex_str}"
         )
+
+    @_render.register
+    def _(self, layer: VLAN, frame: DecodedFrame) -> None:
+        self._print(
+            f"{_I}[+] 802.1Q VLAN (VID {layer.vid}, PCP {layer.pcp}, "
+            f"DEI {layer.dei})"
+        )
+        self._print(f"{_II}EtherType: {layer.ethertype_name}")
 
 
 class OutputToPcap(Output):

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -1,0 +1,66 @@
+"""VLAN-tagged frames decode end-to-end: the tag is a first-class layer
+and the IP payload behind it is reached (single tag and QinQ)."""
+
+import struct
+
+from rootwire.decoder import decode_frame
+
+ETH = struct.Struct("!6s6sH")
+TAG = struct.Struct("!HH")
+
+DST = b"\xaa" * 6
+SRC = b"\xbb" * 6
+
+
+def tagged(inner_ethertype: int, payload: bytes, tci: int = 0x002A) -> bytes:
+    return ETH.pack(DST, SRC, 0x8100) + TAG.pack(tci, inner_ethertype) + payload
+
+
+def ipv4(payload: bytes, proto: int = 6) -> bytes:
+    return (
+        struct.pack(
+            "!BBHHHBBH4s4s",
+            0x45,
+            0,
+            20 + len(payload),
+            0x1234,
+            0,
+            64,
+            proto,
+            0,
+            b"\xc0\xa8\x01\x01",
+            b"\xc0\xa8\x01\x02",
+        )
+        + payload
+    )
+
+
+def test_single_tagged_frame_decodes_to_tcp() -> None:
+    tcp = struct.pack("!HHIIHHHH", 12345, 80, 1, 0, 0x5002, 65535, 0, 0)
+    frame = decode_frame(
+        tagged(0x0800, ipv4(tcp) + b"GET / HTTP/1.1"),
+        number=1,
+        timestamp=0.0,
+        interface="test",
+    )
+    names = [type(layer).__name__ for layer in frame.layers]
+    assert names == ["Ethernet", "VLAN", "IPv4", "TCP"]
+    assert frame.error is None
+
+
+def test_qinq_frame_decodes_one_layer_per_tag() -> None:
+    udp = struct.pack("!HHHH", 5353, 5353, 18, 0) + b"0123456789"
+    outer = ETH.pack(DST, SRC, 0x88A8) + TAG.pack(0, 0x8100)
+    inner = TAG.pack(0x002A, 0x0800) + ipv4(udp, proto=17)
+    frame = decode_frame(
+        outer + inner, number=1, timestamp=0.0, interface="test"
+    )
+    names = [type(layer).__name__ for layer in frame.layers]
+    assert names == ["Ethernet", "VLAN", "VLAN", "IPv4", "UDP"]
+
+
+def test_tagged_frame_truncation_still_detected() -> None:
+    udp = struct.pack("!HHHH", 5353, 5353, 18, 0) + b"0123456789"
+    full = tagged(0x0800, ipv4(udp))
+    frame = decode_frame(full[:-5], number=1, timestamp=0.0, interface="test")
+    assert frame.truncated is True


### PR DESCRIPTION
## Summary

Companion to the NETProtocols VLAN layer PR: renders 802.1Q tags on screen and locks in end-to-end decode of tagged frames.

Before: a tagged frame printed as an Ethernet header with a 58-byte opaque payload and no diagnosis. After: the tag renders as a first-class layer and the IP payload behind it decodes normally.

## What's included

- `output.py` — `VLAN` screen renderer (`[+] 802.1Q VLAN (VID n, PCP n, DEI n)` + inner EtherType).
- `tests/test_vlan.py` — end-to-end: single tag → `[Ethernet, VLAN, IPv4, TCP]`; QinQ → `[Ethernet, VLAN, VLAN, IPv4, UDP]`; truncation detection preserved through a tag.

## Free win worth knowing about

- Tagged TCP traffic now buckets as **TCP in the stats summary** instead of `other`.
- VLAN layers flow into NDJSON output cleanly (scalar fields only).

## Verification

Two-corner audit (Oracle + Windy): 19-case adversarial battery, 65,536-EtherType dispatch differential (3 new / 0 regressed), 7,000-frame fuzz with zero contract escapes, ruff format/check + mypy strict clean, full suites green.

Depends on https://github.com/EONRaider/NETProtocols/pull/35 — this PR's imports resolve once that lands.


Companion triage issue: https://github.com/EONRaider/RootWire/issues/49