### PR TITLE
Bump netprotocols floor to 1.3 and refresh lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ dist/
 venv/
 .venv/
 benchmarks/frames.bin
+
+# Test / coverage artifacts
+.coverage
+.coverage.*
+htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: System :: Networking :: Monitoring",
 ]
-dependencies = ["netprotocols>=1.1,<2"]
+dependencies = ["netprotocols>=1.3,<2"]
 
 [project.scripts]
 rootwire = "rootwire.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -353,11 +353,11 @@ wheels = [
 
 [[package]]
 name = "netprotocols"
-version = "1.1.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/17/e43868caed6bb29d0ba5ec601b8d167f9e93612c6fb4439395bf82a4a919/netprotocols-1.1.0.tar.gz", hash = "sha256:5078957c0e040304e22785746a2450143d0de2433243818efb0f707683ddfe8a", size = 89429, upload-time = "2026-08-29T19:38:54.102Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/19/bc47fdffeafbc20512c90b83c69e2d53c9c3db2c231a62d7c57ab9c03528/netprotocols-1.3.0.tar.gz", hash = "sha256:259190134a1115a65265da48a20b884df796498d62e6045aa035eb83d30f11c5", size = 149744, upload-time = "2026-09-01T21:16:44.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e2/1faabe3042105d1309dc8e1aa485768c35e4875a4cf5d8060da4cfadd473/netprotocols-1.1.0-py3-none-any.whl", hash = "sha256:fde3c0ca3987792f5cfb9fc08adf41b3bb98e3b0d7c2560f521fc3e0be6c37d4", size = 26878, upload-time = "2026-08-29T19:38:52.835Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fa/e6de853d7bd2d93ba61f1bf14770ecf19492ef8607be43dbfd14cc10f0ae/netprotocols-1.3.0-py3-none-any.whl", hash = "sha256:a5537a6726ae03705d04d705d3d85a5abba64649cdd6c07e724504252296eba3", size = 51730, upload-time = "2026-09-01T21:16:43.489Z" },
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "netprotocols", specifier = ">=1.1,<2" }]
+requires-dist = [{ name = "netprotocols", specifier = ">=1.3,<2" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Unblocks #48 from this side, with no push required from the contributor.

#48 fails CI on `ImportError: cannot import name 'VLAN' from 'netprotocols'` (and the matching mypy `attr-defined` error). The cause is not that PR's diff — it is this repository's lockfile. `netprotocols` 1.3.0 exports the VLAN layer (`netprotocols.layer2.vlan.VLAN`, re-exported from the package root), and the existing `>=1.1,<2` constraint already permitted it, but `uv.lock` still resolved to 1.1.0. Since CI runs through `uv run`, every job installed the version that predates the layer.

## Changes

- `uv.lock` — `netprotocols` 1.1.0 → 1.3.0.
- `pyproject.toml` — declared floor `>=1.1,<2` → `>=1.3,<2`.
- `.gitignore` — ignore `.coverage`, `.coverage.*`, `htmlcov/`.

The floor bump is not cosmetic. The lock alone repairs CI and local development, but it does not reach anyone installing the published package: project metadata would continue to advertise 1.1.0 as acceptable, which stops being true the moment VLAN rendering merges. Because #48 does not touch `pyproject.toml`, that declaration can only come from `master`.

The `.gitignore` entry is unrelated housekeeping, kept as a separate commit so it can be dropped independently. `uv run pytest --cov=rootwire` — the command CI runs — writes a `.coverage` database to the repository root. pytest, mypy and ruff each drop a self-excluding `.gitignore` inside their own cache directory; coverage.py does not, so its output is left exposed to anyone running the project's test command.

## Why this unblocks #48 without a contributor push

CI triggers on `pull_request` and uses `actions/checkout@v5` with no explicit `ref`. That default resolves to `refs/pull/<n>/merge` — the ephemeral merge of the PR head into the current base — so #48's jobs never build `2f54e91` in isolation; they build it merged with `master`. That PR touches only `src/rootwire/output.py` and `tests/test_vlan.py`, so the lock and project metadata it compiles against are whatever `master` carries. The two diffs are disjoint, so there is no conflict.

## Verification

Ran the exact commands from `.github/workflows/ci.yml`, both on this branch alone and against a local merge of this branch with `refs/pull/48/head` (`2f54e91`) — the second being what CI will actually build for that PR:

| Check | This branch | Merged with #48 head |
| --- | --- | --- |
| `ruff check` | pass | pass |
| `ruff format --check` | pass | pass |
| `mypy` (strict) | clean, 8 source files | clean, 8 source files |
| `pytest` | 173 passed | 176 passed |

The three additional tests are #48's VLAN cases: single tag, QinQ, and truncation detection through a tag. Coverage on the merged tree is 90% overall, with `src/rootwire/output.py` at 97%.

After this lands, #48 needs only a re-run of its failed jobs, or an "Update branch" if edits by maintainers are enabled on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE

---
_Generated by [Claude Code](https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE)_