### PR TITLE
Add pull request template and correct contributor docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+<!--
+  Thanks for contributing to RootWire.
+
+  Keep this short. A couple of dense paragraphs that explain what changed
+  and why beats a long form with every box ticked. Delete any section that
+  does not apply.
+-->
+
+## Summary
+
+<!--
+  What this changes, and why it is worth changing. If the diff is not
+  obvious on its own, say what the behaviour was before and what it is
+  after. For a bug fix, describe how it failed.
+-->
+
+## Related issues
+
+<!-- e.g. Closes #12 — or "None" for standalone work. -->
+
+## Verification
+
+<!--
+  How you know this works. Name the checks you ran locally and anything
+  you exercised by hand (a capture against a live interface, a replayed
+  pcap, a crafted frame). "CI is green" alone is not verification for a
+  behaviour change.
+-->
+
+- [ ] `uv run ruff check` and `uv run ruff format --check`
+- [ ] `uv run mypy` (strict)
+- [ ] `uv run pytest`
+
+## Checklist
+
+- [ ] Tests cover the new behaviour, including its failure paths.
+- [ ] Dependency changes are locked — ran `uv lock` and committed `uv.lock`
+      alongside the `pyproject.toml` edit.
+- [ ] User-facing changes have a `CHANGELOG.md` entry under *Unreleased*.
+- [ ] Docs updated if this changes the CLI, the output formats, or the
+      decode pipeline (`README.md`, `ARCHITECTURE.md`).
+
+<!--
+  On decoding: RootWire promises that malformed or truncated frames are
+  diagnosed rather than crashing the capture. If you touched the decode
+  path, say how that promise still holds for the inputs you added.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,45 @@
 When contributing to this repository, please first discuss the change you wish to make via issue,
 email, or any other method with the owners of this repository before making a change.
 
-## Pull Request Process
+## Development setup
 
-Contributions are what make the open source community such an amazing place
-to learn, inspire, and create. Any contributions you make are greatly appreciated.
+RootWire is developed with [uv](https://docs.astral.sh/uv/). Clone the
+repository and sync the environment, which installs the project along with the
+`dev` dependency group:
+
+```
+git clone https://github.com/EONRaider/RootWire.git
+cd RootWire
+uv sync
+```
+
+Live capture opens a raw socket and therefore needs root on Linux, but nothing
+in the test suite does. The 65-frame corpus of real captured traffic is
+replayed through the whole pipeline from disk, so the full suite runs
+unprivileged on any operating system.
+
+## Checks
+
+Run these before opening a pull request. They are the same commands CI runs, so
+a clean local run is a good predictor of a green pipeline:
+
+```
+uv run ruff check
+uv run ruff format --check
+uv run mypy
+uv run pytest
+```
+
+`mypy` runs in strict mode over `src`. Tests run against Python 3.12, 3.13 and
+3.14 in CI; locally, whichever interpreter `uv sync` resolved is enough for most
+work.
+
+If you change dependencies in `pyproject.toml`, run `uv lock` and commit the
+updated `uv.lock` in the same change. CI installs from the lockfile, so an
+unlocked dependency edit has no effect on the pipeline and will fail there while
+appearing to work locally.
+
+## Pull Request Process
 
 1. Fork this Project
 2. Create your Feature Branch (`git checkout -b featurebranch/Feature`)
@@ -14,13 +49,38 @@ to learn, inspire, and create. Any contributions you make are greatly appreciate
 4. Push to the Branch (`git push origin featurebranch/Feature`)
 5. Open a Pull Request
 
-- Ensure any install or build dependencies are removed before the end of the layer when doing a build.
-- Update the README.md with details of changes to the interface, this includes new environment variables,
-  exposed ports, useful file locations and container parameters.
-- Increase the version numbers in any examples files and the README.md to the new version that this
-  Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-- You may merge the Pull Request in once you have the sign-off of two other developers, or if you
-  do not have permission to do that, you may request the second reviewer to merge it for you.
+Opening a pull request fills in
+[the template](.github/pull_request_template.md) automatically. It asks what
+changed and why, which checks you ran, and how you verified the behaviour —
+delete whatever does not apply to your change.
+
+Leave *Allow edits by maintainers* enabled on your pull request. It lets a
+maintainer update your branch when the base branch moves under you, which
+resolves conflicts and stale CI without any work on your part.
+
+Beyond that:
+
+- Cover new behaviour with tests, including its failure paths. Malformed and
+  truncated input is diagnosed rather than fatal — see the decoding note below —
+  so the interesting cases are usually the broken ones.
+- Add a `CHANGELOG.md` entry under *Unreleased* for anything user-facing. The
+  format is [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the
+  project follows [SemVer](https://semver.org/).
+- Update `README.md` when you change the command-line interface or the output
+  formats, and `ARCHITECTURE.md` when you change the shape of the pipeline
+  itself — how frames are captured, decoded, or dispatched to outputs.
+
+## A note on decoding
+
+RootWire promises that malformed or truncated frames are diagnosed instead of
+crashing the capture: unknown protocols end the decode chain gracefully, and a
+16-layer cap keeps crafted extension-header stacks from amplifying. That promise
+is the reason the parser is defensive everywhere it touches attacker-controlled
+bytes.
+
+If your change touches the decode path, treat that promise as part of the
+contract you are keeping. Say in the pull request how it still holds for the
+inputs you introduced.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ uv run pytest
 - Kernel timestamps (`SO_TIMESTAMPNS`) and SIGTERM-clean service use
 - Checksum verification rendering (the library already computes them)
 
+## Contributing
+
+Bug reports and pull requests are welcome. [CONTRIBUTING.md](CONTRIBUTING.md)
+covers the development setup, the checks CI runs, and what a good pull request
+looks like here.
+
 ## Legal Disclaimer
 
 The use of code contained in this repository, either in part or in its


### PR DESCRIPTION
## Summary

The repository had no pull request template, so PR bodies were freeform and frequently omitted how a change had been verified. This adds one, and corrects the contributor documentation it points at — which turned out to be largely unedited boilerplate.

## Changes

- **`.github/pull_request_template.md`** (new) — summary, related issues, the three check commands CI runs, and a short checklist. Deliberately light: the house style for descriptions in this repository is a dense paragraph, not a long form, so the template is mostly HTML comments that prompt without rendering.
- **`CONTRIBUTING.md`** — replaced the *Pull Request Process* boilerplate with the real workflow; added *Development setup*, *Checks*, and a short note on the decode-path contract. Code of Conduct section left untouched.
- **`README.md`** — added a Contributing section linking `CONTRIBUTING.md`, which nothing in the README previously referenced.

## Why CONTRIBUTING.md needed correcting

It described a project this is not. Contributors were told to remove build dependencies "before the end of the layer when doing a build" and to document "exposed ports and container parameters" — Docker boilerplate, with no Dockerfile in the repository. It also required "the sign-off of two other developers" before merge, which does not reflect how this repository is actually maintained. Nothing in it mentioned uv, ruff, mypy, or pytest, so a contributor following it exactly would learn nothing about the checks their PR must pass.

The replacement documents what CI actually does: `uv sync` for setup, the four check commands, strict mypy over `src`, and the 3.12/3.13/3.14 test matrix.

## One item earned the hard way

Both the template and CONTRIBUTING.md now call out that a `pyproject.toml` dependency edit must ship with a regenerated `uv.lock`. CI installs from the lockfile, so an unlocked edit has no effect on the pipeline — it fails there while appearing to work locally. That is precisely how the `netprotocols` VLAN import broke #48: the constraint already permitted a working version, but the lock pinned one that predated the layer.

CONTRIBUTING.md also now asks contributors to leave *Allow edits by maintainers* enabled, since that is what lets a maintainer refresh a branch when the base moves underneath it.

## Verification

`uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run pytest` — all clean, 173 passed. Ruff excludes `*.md`, so the documentation changes cannot affect lint; the run confirms the branch is otherwise untouched. All relative links in the new and edited files resolve to existing paths.

No `CHANGELOG.md` entry: these are contributor-facing meta files with no user-visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE

---
_Generated by [Claude Code](https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE)_