### PR TITLE
Resolve #49 audit findings: clobber guard, payload sanitizer, error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- Payload display (`-d`) now neutralizes terminal control characters.
+  Packet payloads are attacker-controlled, and the previous rendering
+  passed ESC and other control bytes straight to the terminal, allowing a
+  crafted frame to inject ANSI escape sequences. Non-printable characters
+  (C0/C1 controls, `DEL`, and Unicode format characters such as the
+  bidirectional overrides) are now shown as visible `\xNN`/`\uXXXX`
+  escapes; printable text and newlines are unchanged (#53).
+
+### Fixed
+- Refuse `-r FILE -w FILE` when both refer to the same file. The writer
+  truncated its target before the lazy replay reader had read a byte, so
+  replaying and writing the same path destroyed the capture; it is now
+  rejected up front, before anything is opened (#52).
+- A `-w` target that cannot be opened (bad directory, permission denied)
+  now reports a clear write-specific error instead of a raw traceback,
+  and no longer risks being misreported as a capture-privilege problem
+  (#54).
+- The end-of-run statistics summary is no longer printed while an
+  unexpected exception is propagating, where it made a crash look like a
+  clean run (#54).
+
 ## [5.0.0] - 2026-08-29
 
 **Packet-Sniffer is now RootWire.** Same engine, new name — and its

--- a/src/rootwire/cli.py
+++ b/src/rootwire/cli.py
@@ -10,6 +10,7 @@ stderr, so stdout stays clean for machine-readable output
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from collections.abc import Iterator, Sequence
 
@@ -78,6 +79,21 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _same_file(a: str, b: str) -> bool:
+    """Whether two path strings name the same file on disk.
+
+    :func:`os.path.samefile` compares device and inode, so it sees
+    through symlinks, hardlinks, and different spellings of an existing
+    path. It raises when a path does not exist yet — as the write target
+    normally does not — and a normalized textual comparison is then the
+    best remaining signal.
+    """
+    try:
+        return os.path.samefile(a, b)
+    except OSError:
+        return os.path.realpath(a) == os.path.realpath(b)
+
+
 def run(
     source: Iterator[tuple[bytes, float]],
     interface: str | None,
@@ -101,6 +117,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.read is not None and args.interface is not None:
         build_parser().error("-r/--read and -i/--interface are exclusive")
+    if (
+        args.read is not None
+        and args.write is not None
+        and _same_file(args.read, args.write)
+    ):
+        # The writer truncates its target on open, before the lazy
+        # replay reader has read a byte, so this would silently destroy
+        # the very capture being replayed. Refuse before anything opens.
+        build_parser().error(
+            "-w/--write and -r/--read refer to the same file; refusing "
+            "to overwrite the capture being replayed"
+        )
 
     stats = StatsCollector()
     outputs: list[Output] = [
@@ -109,7 +137,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         else OutputToScreen(display_payload=args.data)
     ]
     if args.write is not None:
-        outputs.append(OutputToPcap(args.write))
+        try:
+            outputs.append(OutputToPcap(args.write))
+        except OSError as error:
+            # A bad directory or a write-permission denial must not
+            # surface as a raw traceback, nor be folded into the capture
+            # handler below, whose "run with sudo" hint would misdiagnose
+            # it. No output holds a resource yet, so returning is clean.
+            print(
+                f"Error: cannot open '{args.write}' for writing: "
+                f"{error.strerror or error}",
+                file=sys.stderr,
+            )
+            return 1
     outputs.append(stats)
 
     if args.read is not None:
@@ -133,8 +173,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         file=sys.stderr,
     )
     exit_code = 0
+    report_stats = False
     try:
         run(source, interface, outputs)
+        report_stats = True
     except PermissionError:
         print(
             "Error: opening a raw socket requires elevated privileges. "
@@ -148,10 +190,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         exit_code = 1
     except KeyboardInterrupt:
         print("[!] Capture aborted.", file=sys.stderr)
+        report_stats = True
     finally:
         for output in outputs:
             output.close()
-        if exit_code == 0:
+        # Report only on a clean run or a Ctrl-C abort — never while an
+        # unexpected exception is still propagating, where a summary
+        # (with the exit code still reading 0) would disguise the crash.
+        if report_stats:
             stats.report()
     return exit_code
 

--- a/src/rootwire/output.py
+++ b/src/rootwire/output.py
@@ -51,6 +51,31 @@ _I = " " * 4  # base indentation for layer sections
 _II = " " * 8  # indentation for field detail lines
 
 
+def _sanitize_for_terminal(text: str) -> str:
+    r"""Return *text* with terminal-unsafe characters neutralized.
+
+    Payload bytes are attacker-controlled, so escape sequences must never
+    reach the terminal verbatim: a crafted packet could otherwise move the
+    cursor, rewrite the window title, or recolour and erase prior output
+    when displayed with ``-d``. Printable characters and newlines — the
+    intended line structure — pass through unchanged; everything else
+    (C0 controls and ``DEL``, the C1 range ``U+0080`` to ``U+009F``, and
+    Unicode format characters such as the bidirectional overrides) is
+    rendered as a visible ``\xNN`` or ``\uXXXX`` escape.
+
+    :class:`str.isprintable` already reports every one of those categories
+    as non-printable, so a single membership test covers the whole set.
+    """
+    out: list[str] = []
+    for char in text:
+        if char == "\n" or char.isprintable():
+            out.append(char)
+        else:
+            code = ord(char)
+            out.append(f"\\x{code:02x}" if code <= 0xFF else f"\\u{code:04x}")
+    return "".join(out)
+
+
 class Output(ABC):
     """Interface for consumers of decoded frames (screen, file, ...)."""
 
@@ -100,7 +125,7 @@ class OutputToScreen(Output):
                 f"than were captured"
             )
         if self._display_payload and frame.payload:
-            text = frame.payload.decode(errors="ignore")
+            text = _sanitize_for_terminal(frame.payload.decode(errors="ignore"))
             self._print(f"{_I}[+] Payload ({len(frame.payload)} bytes):")
             self._print(f"{_II}{text.replace(chr(10), chr(10) + _II)}")
         self._print("")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
+import shutil
+
 import pytest
 
-from rootwire import __version__
+from conftest import FIXTURES
+from rootwire import __version__, cli
 from rootwire.cli import build_parser
 
 
@@ -20,3 +23,53 @@ class TestCLI:
             build_parser().parse_args(["--version"])
         assert excinfo.value.code == 0
         assert __version__ in capsys.readouterr().out
+
+
+class TestSameFileGuard:
+    def test_read_and_write_same_file_refused_without_truncating(
+        self, tmp_path
+    ):
+        target = tmp_path / "cap.pcap"
+        shutil.copy(FIXTURES / "udp_dns.pcap", target)
+        original = target.read_bytes()
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main(["-r", str(target), "-w", str(target)])
+        assert excinfo.value.code == 2  # usage error, before any open()
+        assert target.read_bytes() == original  # capture left intact
+
+    def test_same_file_detected_through_different_spelling(self, tmp_path):
+        target = tmp_path / "cap.pcap"
+        shutil.copy(FIXTURES / "udp_dns.pcap", target)
+        (tmp_path / "sub").mkdir()
+        spelled = tmp_path / "sub" / ".." / "cap.pcap"
+        original = target.read_bytes()
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main(["-r", str(target), "-w", str(spelled)])
+        assert excinfo.value.code == 2
+        assert target.read_bytes() == original
+
+
+class TestWriteErrorHandling:
+    def test_bad_write_path_is_a_clean_error_not_a_traceback(
+        self, tmp_path, capsys
+    ):
+        bad = tmp_path / "no-such-dir" / "out.pcap"
+        assert (
+            cli.main(["-r", str(FIXTURES / "udp_dns.pcap"), "-w", str(bad)])
+            == 1
+        )
+        err = capsys.readouterr().err
+        assert "for writing" in err
+        assert "sudo" not in err  # not misdiagnosed as a privilege problem
+
+    def test_stats_not_reported_when_an_unexpected_error_propagates(
+        self, capsys, monkeypatch
+    ):
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("decode exploded")
+
+        monkeypatch.setattr(cli, "run", boom)
+        with pytest.raises(RuntimeError, match="decode exploded"):
+            cli.main(["-r", str(FIXTURES / "udp_dns.pcap")])
+        # No stats summary should disguise the crash as a clean run.
+        assert "[=]" not in capsys.readouterr().err

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,5 +1,8 @@
 import io
 
+from netprotocols import UDP, Packet
+
+from conftest import _eth, _ipv4
 from rootwire.decoder import decode_frame
 from rootwire.output import OutputToScreen
 
@@ -9,6 +12,18 @@ def render(data: bytes, *, display_payload: bool = False) -> str:
     output = OutputToScreen(display_payload=display_payload, stream=stream)
     output.update(decode_frame(data, number=1, timestamp=0.0, interface="eth0"))
     return stream.getvalue()
+
+
+def _frame_with_payload(payload: bytes) -> bytes:
+    """Ethernet / IPv4 / UDP carrying an arbitrary, attacker-shaped
+    payload — the bytes a hostile peer controls end to end. The ports are
+    unassigned so the decoder leaves the payload as raw frame bytes rather
+    than handing it to an upper-layer parser."""
+    udp = UDP(
+        src_port=40000, dst_port=40001, length=8 + len(payload), checksum=0
+    )
+    ip = _ipv4(protocol=17, total_length=20 + 8 + len(payload))
+    return bytes(Packet(_eth(0x0800), ip, udp)) + payload
 
 
 class TestOutputToScreen:
@@ -38,6 +53,35 @@ class TestOutputToScreen:
         assert "GET / HTTP" in render(
             tcp_frame_with_options, display_payload=True
         )
+
+    def test_payload_ansi_escapes_are_neutralized(self):
+        """An attacker-controlled payload must not smuggle ANSI escape
+        sequences into the analyst's terminal via -d."""
+        frame = _frame_with_payload(b"\x1b[2J\x1b[31mowned\x1b[0m")
+        text = render(frame, display_payload=True)
+        assert "\x1b" not in text  # no raw ESC reaches the terminal
+        assert "\\x1b[2J" in text  # rendered as a visible escape instead
+        assert "owned" in text  # printable content still shown
+
+    def test_payload_carriage_return_is_escaped(self):
+        """CR can rewrite the current line; it must not pass through."""
+        frame = _frame_with_payload(b"real\rspoofed")
+        text = render(frame, display_payload=True)
+        assert "\r" not in text
+        assert "\\x0d" in text
+
+    def test_payload_c1_and_bidi_controls_are_escaped(self):
+        """C1 (U+0080 to U+009F) and bidi overrides are non-printable."""
+        frame = _frame_with_payload("\x85\u202eevil".encode())
+        text = render(frame, display_payload=True)
+        assert "\x85" not in text and "\u202e" not in text
+        assert "\\x85" in text and "\\u202e" in text
+
+    def test_payload_newlines_survive_sanitization(self):
+        """Newlines are the intended line structure and are preserved."""
+        frame = _frame_with_payload(b"line-one\nline-two")
+        text = render(frame, display_payload=True)
+        assert "line-one" in text and "line-two" in text
 
     def test_unknown_and_truncated_diagnostics(
         self, unknown_ethertype_frame, truncated_frame


### PR DESCRIPTION
## Summary

Resolves the three actionable findings split out of the two-corner audit (#49) into their own trackers. All three were confirmed against the current code before fixing.

This is one PR for three linked findings rather than three PRs: two of them (#52, #54) live in the same `main()` function in `src/rootwire/cli.py`, so separate branches would force an artificial merge ordering and a rebase for no review benefit. The three commits' worth of change is small and each finding is called out below; the PR closes all three issues.

## Findings fixed

### #52 — `-r X -w X` same-file clobber (medium, data loss)

`OutputToPcap` opens its target `"wb"` (truncating) during output setup, before the lazy `read_pcap` generator reads a byte — so replaying and writing the same path destroyed the capture, then reported a misleading "too short to be a pcap file". `main()` now refuses when both paths resolve to the same file, via `os.path.samefile` (which sees through symlinks, hardlinks, and path spelling) with a `realpath` fallback for the not-yet-existing target. The refusal is a usage error (exit 2) and happens **before anything is opened**, so nothing is truncated.

### #53 — terminal escape injection via `-d` (medium, security)

Payload display decoded attacker-controlled bytes with `errors="ignore"` and passed every control character — ESC included — straight to the terminal, so a crafted frame could inject ANSI escape sequences into the analyst's session. A new `_sanitize_for_terminal` keeps printable characters and newlines and rewrites everything else as visible `\xNN`/`\uXXXX` escapes. `str.isprintable()` reports the whole dangerous set as non-printable — C0/C1 controls, `DEL`, and Unicode format characters including the bidirectional overrides — so a single pass covers it. Screen output only; `--json` was already hex-safe and `-w` writes raw bytes by design.

### #54 — `main()` error handling (low)

Two defects in the same `try`/`finally`:
- The `-w` writer was built outside the `try`, so a bad path exited with a raw traceback. It now has its own `OSError` handler with a write-specific message, kept separate from the capture handler whose "run with sudo" hint would otherwise misdiagnose a write-permission error.
- The end-of-run stats summary was gated on `exit_code == 0`, which stays `0` while an *uncaught* exception propagates — so a crash printed a clean-looking summary. It is now gated on a flag set only on a clean run or a `Ctrl-C` abort.

## Tests

Eight new cases: same-file refusal leaves the file byte-intact (direct, and via a redundant `..` path spelling); a bad write path is a clean error with no traceback and no "sudo"; the stats summary stays silent when an unexpected error propagates; and payload ANSI / CR / C1 / bidi sequences are neutralized while newlines survive.

## Verification

`uv run ruff check`, `uv run ruff format --check`, `uv run mypy` (strict), `uv run pytest` — all clean, 184 passed. Also smoke-tested through the installed `rootwire` entry point: the clobber is refused with the file left at its original size, the bad-write path prints the friendly error, and a crafted ESC/CR/C1 payload renders as escapes.

Closes #52
Closes #53
Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE

---
_Generated by [Claude Code](https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE)_