### PR TITLE
Add socketless tests for the raw-socket capture source

### DIFF
--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,0 +1,93 @@
+"""Raw-socket frame source, exercised without a real socket.
+
+``capture`` is the only module that touches ``PF_PACKET``, which needs
+``CAP_NET_RAW`` — so the loop logic (bind, ``recv``, timestamp, tuple
+shape) is tested against a fake socket swapped in for the module-global
+``socket`` name. Nothing here opens a kernel socket, so it runs
+unprivileged on any Linux runner. The real ``PF_PACKET`` round trip
+belongs in a separate, privilege-gated integration test.
+"""
+
+from itertools import islice
+
+import rootwire.capture as capture_mod
+from rootwire.capture import BUFFER_SIZE, capture
+
+
+class _FakeSocket:
+    """Stand-in for the raw socket: records how it was called and serves
+    a fixed run of canned frames from ``recv``."""
+
+    def __init__(self, *args: int) -> None:
+        self.init_args = args
+        self.bind_args: tuple[str, int] | None = None
+        self.recv_sizes: list[int] = []
+        self.closed = False
+        self._frames = [b"\xaa\xbb", b"\xcc\xdd", b"\xee\xff"]
+        self._index = 0
+
+    def bind(self, address: tuple[str, int]) -> None:
+        self.bind_args = address
+
+    def recv(self, size: int) -> bytes:
+        self.recv_sizes.append(size)
+        frame = self._frames[self._index % len(self._frames)]
+        self._index += 1
+        return frame
+
+    def __enter__(self) -> "_FakeSocket":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        self.closed = True
+        return False
+
+
+class TestCapture:
+    def test_binds_to_interface_and_yields_timestamped_frames(
+        self, monkeypatch
+    ):
+        created: dict[str, _FakeSocket] = {}
+        monkeypatch.setattr(
+            capture_mod,
+            "socket",
+            lambda *args: created.setdefault("sock", _FakeSocket(*args)),
+        )
+        monkeypatch.setattr(capture_mod.time, "time", lambda: 123.5)
+
+        frames = list(islice(capture("eth0"), 3))
+
+        sock = created["sock"]
+        assert sock.bind_args == ("eth0", 0)
+        assert sock.recv_sizes == [BUFFER_SIZE] * 3  # full buffer each recv
+        assert frames == [
+            (b"\xaa\xbb", 123.5),
+            (b"\xcc\xdd", 123.5),
+            (b"\xee\xff", 123.5),
+        ]
+
+    def test_all_interfaces_capture_does_not_bind(self, monkeypatch):
+        created: dict[str, _FakeSocket] = {}
+        monkeypatch.setattr(
+            capture_mod,
+            "socket",
+            lambda *args: created.setdefault("sock", _FakeSocket(*args)),
+        )
+
+        next(iter(capture(None)))
+
+        assert created["sock"].bind_args is None  # None -> capture on all
+
+    def test_socket_is_closed_when_the_generator_is_closed(self, monkeypatch):
+        created: dict[str, _FakeSocket] = {}
+        monkeypatch.setattr(
+            capture_mod,
+            "socket",
+            lambda *args: created.setdefault("sock", _FakeSocket(*args)),
+        )
+
+        frames = capture(None)
+        next(frames)
+        frames.close()  # unwinds the `with`, closing the socket
+
+        assert created["sock"].closed is True


### PR DESCRIPTION
## Summary

`src/rootwire/capture.py` was the only module with no test coverage (0%, 13/13 lines unhit). This adds `tests/test_capture.py` and takes it to 100%, with no change to production code.

## Why it was uncovered — and why that was not a real barrier

The suite never called `capture()` for two reasons that look like blockers but are not:

- A real `PF_PACKET` socket needs `CAP_NET_RAW`. But that privileged syscall is the *only* part that needs root, and it is reached through the module-global `socket` name — so it can be swapped for a fake before `capture()` runs. The loop never touches the kernel.
- The generator loops forever. `itertools.islice` bounds it to a fixed number of frames.

With those two moves the loop logic is fully exercised unprivileged, on the existing `ubuntu-latest` runner (`PF_PACKET` only needs to be *importable*, which it is on Linux — never *bound*).

## What the tests assert

- The raw socket is created, and `bind((interface, 0))` is called when an interface is given.
- Capturing on all interfaces (`None`) does **not** bind.
- `recv` is called with the full `BUFFER_SIZE` each iteration.
- Each frame is yielded paired with its timestamp (`time.time` monkeypatched for determinism).
- The socket is closed when the generator is closed (the `with` unwinds).

## Deliberately out of scope

The real `PF_PACKET` round trip — a frame placed on the wire arriving through `recv` — is a fidelity check the mock cannot make. It needs privileges and belongs in a separate, gated integration test (`skipif(os.geteuid() != 0)`), run in a root-capable CI lane or nightly. That is a fidelity gap, not a line-coverage gap, and is not addressed here.

## Note for the roadmap work

This also sets the seam pattern for #33 (BPF filter attach) and #36 (`SO_TIMESTAMPNS`, SIGTERM, multi-interface), both of which extend `capture.py`: inject the socket dependency, and keep the pure logic (filter compilation, cmsg parsing) separable, so the same socketless strategy reaches the new code.

## Verification

`uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run pytest` — all clean, 187 passed. `capture.py` coverage 0% → 100%; project total 94%.

No `CHANGELOG.md` entry: tests only, no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE

---
_Generated by [Claude Code](https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE)_