### PR TITLE
Diagnose IPv4 total_length smaller than its own header (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Diagnose IPv4 frames whose `total_length` is smaller than the header
+  itself — a length field that cannot be correct. The frame is flagged
+  `[!] Malformed` on screen, carries a `malformed_length` field in NDJSON
+  output, and counts toward the statistics `malformed` tally; upper layers
+  are still decoded and shown. A `total_length` of 0 is exempt, being the
+  large-send offload (TSO) sentinel found in locally captured frames
+  rather than corruption (#56).
+
 ### Security
 - Payload display (`-d`) now neutralizes terminal control characters.
   Packet payloads are attacker-controlled, and the previous rendering

--- a/src/rootwire/decoder.py
+++ b/src/rootwire/decoder.py
@@ -36,6 +36,25 @@ def _declared_length(layers: tuple[Protocol, ...]) -> int | None:
     return None
 
 
+def _ip_length_malformed(layers: tuple[Protocol, ...]) -> bool:
+    """Whether a decoded IPv4 header declares an impossible length.
+
+    ``total_length`` counts the whole datagram — header plus data — so a
+    value below the header's own size cannot be correct. The walk advances
+    on ``header_len`` (from ``ihl``), not on ``total_length``, so this does
+    not corrupt decoding; it is purely a diagnosis of a lying length field.
+
+    A ``total_length`` of 0 is exempt: it is the sentinel large-send
+    offload (TSO) leaves in locally captured outbound frames, where the
+    real length is filled in by hardware after capture. Flagging it would
+    cry wolf on ordinary local traffic.
+    """
+    for layer in layers:
+        if isinstance(layer, IPv4):
+            return 0 < layer.total_length < layer.header_len
+    return False
+
+
 def decode_frame(
     data: bytes,
     *,
@@ -80,6 +99,7 @@ def decode_frame(
         layers=decoded_layers,
         payload=bytes(view[cursor:]),
         truncated=declared is not None and declared > len(data),
+        malformed_length=_ip_length_malformed(decoded_layers),
         error=error,
         raw=data,
     )

--- a/src/rootwire/frame.py
+++ b/src/rootwire/frame.py
@@ -31,6 +31,12 @@ class DecodedFrame:
     :param payload: The bytes following the last decoded header.
     :param truncated: True when the enclosed IP datagram declares more
         bytes than were captured (the payload is incomplete).
+    :param malformed_length: True when a decoded IPv4 header declares a
+        ``total_length`` smaller than the header itself — an impossible
+        value. A ``total_length`` of 0 is exempt: it is the sentinel
+        large-send offload (TSO) leaves in locally captured frames, not
+        corruption. Upper layers are still decoded and shown; this only
+        adds the diagnosis.
     :param error: Diagnostic message when the decode chain aborted on a
         malformed header, else ``None``. The layers decoded before the
         failure are preserved.
@@ -46,6 +52,7 @@ class DecodedFrame:
     layers: tuple[Protocol, ...]
     payload: bytes
     truncated: bool = False
+    malformed_length: bool = False
     error: str | None = None
     raw: bytes = b""
 

--- a/src/rootwire/output.py
+++ b/src/rootwire/output.py
@@ -124,6 +124,11 @@ class OutputToScreen(Output):
                 f"{_I}[!] Truncated: the IP datagram declares more bytes "
                 f"than were captured"
             )
+        if frame.malformed_length and (ip := frame.layer(IPv4)) is not None:
+            self._print(
+                f"{_I}[!] Malformed: IPv4 total_length ({ip.total_length}) "
+                f"is smaller than its header ({ip.header_len} bytes)"
+            )
         if self._display_payload and frame.payload:
             text = _sanitize_for_terminal(frame.payload.decode(errors="ignore"))
             self._print(f"{_I}[+] Payload ({len(frame.payload)} bytes):")
@@ -320,6 +325,7 @@ class OutputToNDJSON(Output):
             "interface": frame.interface,
             "length": frame.length,
             "truncated": frame.truncated,
+            "malformed_length": frame.malformed_length,
             "error": frame.error,
             "payload_len": len(frame.payload),
             "layers": [
@@ -368,7 +374,7 @@ class StatsCollector(Output):
     def update(self, frame: DecodedFrame) -> None:
         self._frames += 1
         self._bytes += frame.length
-        if frame.error is not None:
+        if frame.error is not None or frame.malformed_length:
             self._malformed += 1
         if frame.truncated:
             self._truncated += 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,17 @@ def _ipv4(protocol: int, total_length: int, options: bytes = b"") -> IPv4:
     )
 
 
+def ipv4_udp(total_length: int, payload: bytes = b"\xaa\xbb") -> bytes:
+    """Ethernet / IPv4 / UDP with a caller-chosen IPv4 ``total_length``,
+    for exercising length diagnostics. The ports are unassigned so the
+    decoder leaves the payload as raw frame bytes."""
+    udp = UDP(
+        src_port=40000, dst_port=40001, length=8 + len(payload), checksum=0
+    )
+    ip = _ipv4(protocol=17, total_length=total_length)
+    return bytes(Packet(_eth(0x0800), ip, udp)) + payload
+
+
 @pytest.fixture
 def arp_frame() -> bytes:
     return bytes(

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,5 +1,6 @@
 from netprotocols import ARP, TCP, UDP, Ethernet, ICMPv4, ICMPv6, IPv4, IPv6
 
+from conftest import ipv4_udp
 from rootwire.decoder import decode_frame
 
 
@@ -65,6 +66,32 @@ class TestDecodeFrame:
         assert frame.error is not None
         assert "TCP" in frame.error
         assert frame.truncated
+
+    def test_ipv4_total_length_below_header_is_flagged(self):
+        """A total_length smaller than the 20-byte header is impossible;
+        it is diagnosed, and upper layers are still decoded (the walk runs
+        off header_len, not total_length)."""
+        frame = decode(ipv4_udp(total_length=4))
+        assert frame.malformed_length
+        assert [type(layer) for layer in frame.layers] == [
+            Ethernet,
+            IPv4,
+            UDP,
+        ]
+        assert frame.error is None
+        assert not frame.truncated
+
+    def test_ipv4_total_length_zero_is_not_flagged(self):
+        """total_length == 0 is the large-send offload (TSO) sentinel in
+        locally captured frames, not corruption."""
+        assert not decode(ipv4_udp(total_length=0)).malformed_length
+
+    def test_ipv4_total_length_equal_to_header_is_not_flagged(self):
+        """A header-only datagram (total_length == header) is valid."""
+        assert not decode(ipv4_udp(total_length=20)).malformed_length
+
+    def test_ipv4_valid_total_length_is_not_flagged(self):
+        assert not decode(ipv4_udp(total_length=20 + 8 + 2)).malformed_length
 
     def test_metadata_carried_through(self, arp_frame):
         frame = decode_frame(

--- a/tests/test_ndjson_stats.py
+++ b/tests/test_ndjson_stats.py
@@ -3,7 +3,7 @@
 import io
 import json
 
-from conftest import FIXTURES
+from conftest import FIXTURES, ipv4_udp
 from rootwire import cli
 from rootwire.decoder import decode_frame
 from rootwire.output import OutputToNDJSON, StatsCollector
@@ -14,6 +14,7 @@ SCHEMA_KEYS = {
     "interface",
     "length",
     "truncated",
+    "malformed_length",
     "error",
     "payload_len",
     "layers",
@@ -97,6 +98,12 @@ class TestStatsCollector:
         stream = io.StringIO()
         stats.report(stream)
         assert "malformed: 1, truncated: 1" in stream.getvalue()
+
+    def test_underlength_ip_counts_as_malformed(self):
+        stats = self.collect([ipv4_udp(total_length=4)])
+        stream = io.StringIO()
+        stats.report(stream)
+        assert "malformed: 1" in stream.getvalue()
 
 
 class TestJSONModePurity:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -2,7 +2,7 @@ import io
 
 from netprotocols import UDP, Packet
 
-from conftest import _eth, _ipv4
+from conftest import _eth, _ipv4, ipv4_udp
 from rootwire.decoder import decode_frame
 from rootwire.output import OutputToScreen
 
@@ -90,6 +90,11 @@ class TestOutputToScreen:
         truncated_text = render(truncated_frame)
         assert "Malformed header: TCP" in truncated_text
         assert "Truncated" in truncated_text
+
+    def test_malformed_ip_length_is_diagnosed(self):
+        text = render(ipv4_udp(total_length=4))
+        assert "Malformed: IPv4 total_length (4)" in text
+        assert "smaller than its header (20 bytes)" in text
 
 
 class TestExtensionHeaderRendering:


### PR DESCRIPTION
## Summary

Closes #56 — the last carried-forward finding from the #49 audit. An IPv4 header whose `total_length` is smaller than the header it sits on declares an impossible size (a datagram cannot be shorter than its own header). It was trusted silently; now it is diagnosed, mirroring the truncation case the decoder already reports.

## Approach

- **New flag** `DecodedFrame.malformed_length`, set when a decoded IPv4 layer has `0 < total_length < header_len`.
- **Upper layers still decode.** The walk advances on `header_len` (from `ihl`), never on `total_length` (`decoder.py`), so an under-length value doesn't corrupt decoding — this is purely an added diagnosis. The frame shows its layers *and* the warning, exactly as truncated frames do.
- **Surfaced everywhere the existing diagnostics are**: an `[!] Malformed` line on screen naming the offending value and the header size, a `malformed_length` field in NDJSON, and the statistics `malformed` tally (a frame is malformed if the chain aborted *or* the length is impossible).

## The one subtlety that makes this correct: `total_length == 0` is exempt

`total_length == 0` is not corruption — it is the sentinel that large-send offload (TSO) leaves in locally captured *outbound* frames, where the real length is filled in by hardware after the capture point. These are the "length 0" packets tcpdump shows routinely on loopback. A naive `total_length < header_len` check would raise a false positive on ordinary local traffic, so only a **non-zero** under-length value is treated as malformed. The existing `truncated` check already tolerates `total_length == 0` (declared `14` never exceeds a real capture length); this keeps the two length diagnostics consistent.

## Tests

Boundary-complete: under-length flagged with upper layers still decoded; `total_length` of `0` (TSO), `== header`, and a valid full length all left unflagged; plus the screen, NDJSON (schema + value), and stats surfaces. A shared `ipv4_udp(total_length=…)` builder in `conftest.py` keeps the cases readable.

## Verification

`uv run ruff check`, `uv run ruff format --check`, `uv run mypy` (strict), `uv run pytest` — all clean, **193 passed**. Also smoke-tested through the installed `rootwire` binary on a crafted two-frame pcap: the under-length frame renders the `[!] Malformed` line and reports `malformed_length: true` / `malformed: 1`, while the `total_length == 0` frame is correctly silent.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE

---
_Generated by [Claude Code](https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE)_