### PR TITLE
Handle SIGTERM as a clean shutdown, same as Ctrl-C (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are still decoded and shown. A `total_length` of 0 is exempt, being the
   large-send offload (TSO) sentinel found in locally captured frames
   rather than corruption (#56).
+- Handle `SIGTERM` as a clean shutdown, the same as Ctrl-C: flush every
+  output, print the stats summary, and exit 0. Previously only `SIGINT`
+  was handled — a service manager's stop (or plain `kill`) hit Python's
+  default disposition, which terminates immediately and skips output
+  flushing entirely, losing the tail of a `-w` capture and the run
+  summary (#60).
 
 ### Security
 - Payload display (`-d`) now neutralizes terminal control characters.

--- a/src/rootwire/cli.py
+++ b/src/rootwire/cli.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 
 import argparse
 import os
+import signal
 import sys
 from collections.abc import Iterator, Sequence
+from types import FrameType
+from typing import NoReturn
 
 from rootwire import __version__
 from rootwire.decoder import decode_frame
@@ -77,6 +80,26 @@ def build_parser() -> argparse.ArgumentParser:
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
     return parser
+
+
+class _Terminated(KeyboardInterrupt):
+    """Raised by the SIGTERM handler.
+
+    A :class:`KeyboardInterrupt` subclass so a SIGTERM abort shares
+    Ctrl-C's shutdown path (flush outputs, report stats, exit 0) without
+    a second ``except`` clause, while still being distinguishable for the
+    shutdown message.
+    """
+
+
+def _raise_terminated(signum: int, frame: FrameType | None) -> NoReturn:
+    """SIGTERM handler: raise to interrupt whatever is currently
+    blocked (a raw-socket ``recv`` or the replay loop) instead of
+    Python's default disposition, which terminates the process outright
+    and skips ``finally`` blocks — losing unflushed output and the
+    stats summary.
+    """
+    raise _Terminated
 
 
 def _same_file(a: str, b: str) -> bool:
@@ -174,6 +197,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     exit_code = 0
     report_stats = False
+    # Only for the duration of the capture: a service manager's SIGTERM
+    # should stop the run cleanly, the same as Ctrl-C, instead of hitting
+    # Python's default disposition (immediate termination, no `finally`,
+    # unflushed output). Restored below so importing rootwire as a
+    # library never hijacks the caller's signal handling.
+    previous_sigterm_handler = signal.signal(signal.SIGTERM, _raise_terminated)
     try:
         run(source, interface, outputs)
         report_stats = True
@@ -188,15 +217,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ValueError as e:  # unreadable/foreign pcap on -r
         print(f"Error: {e}", file=sys.stderr)
         exit_code = 1
-    except KeyboardInterrupt:
-        print("[!] Capture aborted.", file=sys.stderr)
+    except KeyboardInterrupt as abort:
+        print(
+            "[!] Terminated."
+            if isinstance(abort, _Terminated)
+            else "[!] Capture aborted.",
+            file=sys.stderr,
+        )
         report_stats = True
     finally:
+        signal.signal(signal.SIGTERM, previous_sigterm_handler)
         for output in outputs:
             output.close()
-        # Report only on a clean run or a Ctrl-C abort — never while an
-        # unexpected exception is still propagating, where a summary
-        # (with the exit code still reading 0) would disguise the crash.
+        # Report only on a clean run or an abort (Ctrl-C or SIGTERM) —
+        # never while an unexpected exception is still propagating, where
+        # a summary (with the exit code still reading 0) would disguise
+        # the crash.
         if report_stats:
             stats.report()
     return exit_code

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 import shutil
+import signal
 
 import pytest
 
+import rootwire.capture as capture_mod
 from conftest import FIXTURES
 from rootwire import __version__, cli
 from rootwire.cli import build_parser
@@ -73,3 +75,87 @@ class TestWriteErrorHandling:
             cli.main(["-r", str(FIXTURES / "udp_dns.pcap")])
         # No stats summary should disguise the crash as a clean run.
         assert "[=]" not in capsys.readouterr().err
+
+
+class _SignalDeliveringSocket:
+    """Fake capture socket whose recv() simulates real SIGTERM delivery
+    by invoking whatever handler main() currently has installed for it
+    (fetched dynamically via signal.getsignal), instead of blocking.
+
+    This exercises the exact function main() registers and the exact
+    exception-propagation path a live interruption would take — through
+    capture()'s generator, out of recv(), through run()'s loop — without
+    sending a real signal to the test process.
+    """
+
+    def __init__(self, *args: int) -> None:
+        pass
+
+    def bind(self, address: tuple[str, int]) -> None:
+        pass
+
+    def recv(self, size: int) -> bytes:
+        handler = signal.getsignal(signal.SIGTERM)
+        if not callable(handler):
+            raise AssertionError(
+                "main() did not install a callable SIGTERM handler"
+            )
+        handler(signal.SIGTERM, None)
+        raise AssertionError("SIGTERM handler returned instead of raising")
+
+    def __enter__(self) -> "_SignalDeliveringSocket":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+class TestAbortHandling:
+    """Ctrl-C (KeyboardInterrupt) and a service manager's SIGTERM both
+    abort main()'s capture loop through the same shutdown path: flush
+    outputs, report stats, exit 0."""
+
+    def test_keyboard_interrupt_flushes_and_reports_then_exits_cleanly(
+        self, capsys, monkeypatch
+    ):
+        def raise_interrupt(*_args, **_kwargs):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(cli, "run", raise_interrupt)
+        assert cli.main(["-r", str(FIXTURES / "udp_dns.pcap")]) == 0
+        err = capsys.readouterr().err
+        assert "[!] Capture aborted." in err
+        assert "frames/s" in err  # stats were reported: outputs flushed
+
+    def test_sigterm_flushes_and_reports_then_exits_cleanly(
+        self, capsys, monkeypatch
+    ):
+        monkeypatch.setattr(
+            capture_mod, "socket", lambda *args: _SignalDeliveringSocket()
+        )
+        assert cli.main(["-i", "eth0"]) == 0
+        err = capsys.readouterr().err
+        assert "[!] Terminated." in err
+        assert "[!] Capture aborted." not in err
+        assert "frames/s" in err  # stats were reported: outputs flushed
+
+    def test_sigterm_handler_is_restored_after_main_returns(self, monkeypatch):
+        monkeypatch.setattr(
+            capture_mod, "socket", lambda *args: _SignalDeliveringSocket()
+        )
+        original_handler = signal.getsignal(signal.SIGTERM)
+        cli.main(["-i", "eth0"])
+        assert signal.getsignal(signal.SIGTERM) is original_handler
+
+    def test_sigterm_still_flushes_a_pcap_writer(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            capture_mod, "socket", lambda *args: _SignalDeliveringSocket()
+        )
+        out = tmp_path / "out.pcap"
+        assert cli.main(["-i", "eth0", "-w", str(out)]) == 0
+        # PcapWriter's global header is 24 bytes and no frame was ever
+        # captured (the fake socket raises on its first recv). Seeing
+        # exactly 24 bytes on disk proves close() ran and flushed the
+        # writer, rather than the process exiting with the write still
+        # sitting in an unflushed buffer.
+        assert out.stat().st_size == 24


### PR DESCRIPTION
## Summary

Closes #60. Only `SIGINT` (Ctrl-C) triggered `main()`'s clean-shutdown path — flush every output, print the stats summary, exit 0. `SIGTERM` (how a service manager, `timeout`, or a plain `kill` stops a process) hit Python's default disposition instead: immediate termination, no `finally` block, no flush. A `-w` capture's tail and the run summary were both lost.

## Approach

- Install a `SIGTERM` handler for the duration of the capture that raises `_Terminated`, a `KeyboardInterrupt` subclass. It shares the existing `except KeyboardInterrupt` shutdown path without a second `except` clause, while printing its own `[!] Terminated.` message so the two abort sources stay distinguishable in the log.
- The handler is installed right before entering the `try` block and restored in the `finally`, so importing `rootwire` as a library never hijacks the caller's signal handling.
- **Raising matters, not just handling.** Per PEP 475, a Python signal handler that returns lets the interrupted syscall auto-retry; one that raises propagates the exception instead — that's what actually interrupts a blocked `socket.recv()` or the replay loop rather than silently resuming it.

## Tests

Exercise the exact function `main()` installs, fetched dynamically via `signal.getsignal()` and invoked from a fake capture socket's `recv()` (the #57 seam) — this runs the real exception-propagation path (through `capture()`'s generator, out of `recv()`, through `run()`'s loop) without sending an actual signal to the test process:
- clean exit + stats reported
- the pcap writer still flushed (exact 24-byte global header on disk, proving `close()` ran rather than the process exiting with the write still buffered)
- the previous handler restored after `main()` returns
- a companion Ctrl-C test, closing a pre-existing gap — there was no test at all for the `KeyboardInterrupt` path before this PR

## Verification beyond the test suite

Ran a real subprocess doing live capture on `lo` as root, with a genuine OS-delivered `SIGTERM` (not mocked) — and confirmed the regression exists on the unpatched code first:

| | Before | After |
|---|---|---|
| exit code | `-15` (killed) | `0` |
| stderr | nothing | `[!] Terminated.` + stats summary |

`uv run ruff check`, `uv run ruff format --check`, `uv run mypy` (strict), `uv run pytest` — all clean, **197 passed**.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE

---
_Generated by [Claude Code](https://claude.ai/code/session_011Pzk7abZJvAqiCeKE6w2gE)_